### PR TITLE
Slightly better treatment of suspend and resume in promise.notifyAll

### DIFF
--- a/lib/promise.js
+++ b/lib/promise.js
@@ -175,7 +175,7 @@ function Deferred(canceller){
 				if(previousContext && previousContext.resume){
 					previousContext.resume();
 				}
-                exports.currentContext = previousContext;
+				exports.currentContext = previousContext;
 			}
 		}
 	}


### PR DESCRIPTION
This code makes sure that the previous context, if there is one, is suspended and resumed correctly when notifyAll is called.

Most of the time, there shouldn't actually be a previous context, but this code will deal with it correctly if it is there.  The assumption I make here is that if a context is suspended anywhere else, that it should be removed from currentContext (otherwise suspend could get called twice).

Architecturally, it might be better to not expose the currentContext variable, and instead expose get, suspend, resume, and end functions that take care of this housekeeping.  I have seen a couple of places in other code where suspend was called without resetting currentContext, or currentContext was cleared without suspending the context.  However, those issues can be dealt with separately.

This change is part of the foundation for fixes to perstore/transaction that I intend to contribute soon.  I and my employer Quantivo have a CLA on file already.
