### PR TITLE
Promise.call() bag

### DIFF
--- a/promise.js
+++ b/promise.js
@@ -86,8 +86,9 @@ Promise.prototype.put = function(propertyName, value){
 };
 
 Promise.prototype.call = function(functionName /*, args */){
+	var fnArgs = Array.prototype.slice.call(arguments, 1);
 	return this.then(function(value){
-		return value[functionName].apply(value, Array.prototype.slice.call(arguments, 1));
+		return value[functionName].apply(value, fnArgs);
 	});
 };
 


### PR DESCRIPTION
Hi. I found that arguments from call request are not passed to the target objects method. i.e. promise.call('method', arg1, arg2) results in target.method() instead target.method(arg1, arg2); 
This request contains fix.
