### PR TITLE
remove empty deps array

### DIFF
--- a/process.js
+++ b/process.js
@@ -1,5 +1,5 @@
 ({define:typeof define!="undefined"?define:function(deps, factory){factory(require,exports)}}).
-define([], function(req,exports){
+define(function(req,exports){
 if(typeof console !== "undefined"){
 	exports.print = function(){
 		console.log.apply(console, arguments);


### PR DESCRIPTION
in dojo, an empty deps array is an explicit signal not to pass in require, exports, module

this causes `exports` to be undefined when loaded via dojo.
