### PR TITLE
Make all() handle multiple rejected promises. Call rejected as soon as possible.

### DIFF
--- a/promise.js
+++ b/promise.js
@@ -487,19 +487,14 @@ exports.all = function(array){
 					results[index] = value;
 					fulfilled++;
 					if(fulfilled === length){
-						if(!rejected){
-							 deferred.resolve(results);
-						} else {
-							 deferred.reject(rejected);
-						}
+						deferred.resolve(results);
 					}
 				},
 				function(error){
-					fulfilled++;
-					rejected = error;
-					if(fulfilled === length){
+					if(!rejected){
 						 deferred.reject(error);
 					}
+					rejected = true;
 				});
 		});
 	}

--- a/tests/promise.js
+++ b/tests/promise.js
@@ -35,17 +35,25 @@ exports.testWhenPromiseRejectHandled = function(){
 };
 
 exports.testMultipleReject = function(){
-	all(delayedFail(25), delayedFail(50)).then(function () {
+	all(delayedFail(25), delayedFail(50), delayedSuccess(75)).then(function () {
 		throw new Error('There should be no success here.');
 	}, function () {
 		// This is where we want to end up, once only.
 	});
 };
 
+function delayedSuccess(delay) {
+	var deferred = defer();
+	setTimeout(function () {
+		deferred.resolve();
+	}, delay);
+	return deferred.promise;
+}
+
 function delayedFail(delay) {
 	var deferred = defer();
 	setTimeout(function () {
-		deferred.reject(new Error());
+		deferred.reject();
 	}, delay);
 	return deferred.promise;
 }


### PR DESCRIPTION
This fixes issue #30.

The newly added if-clause ensures the all() promise isn't rejected twice. The all() promise is rejected as soon as first promise in the array is rejected. 
