### PR TITLE
Utility function for wrapping a bare value in a promise

### DIFF
--- a/promise.js
+++ b/promise.js
@@ -667,9 +667,9 @@ exports.convertNodeAsyncFunction = function(asyncFunction, callbackNotDeclared){
  * Returns a promise. If the object is already a Promise it is returned; otherwise
  * the object is wrapped in a Promise.
  * @param value	 The value to be treated as a Promise
- * @return A promise wrapping the original value0
+ * @return A promise wrapping the original value
  */
-exports.asPromise = function(value){
+exports.as = function(value){
 	if (value instanceof Promise) {
 		return value;
 	} else {

--- a/tests/promise.js
+++ b/tests/promise.js
@@ -3,7 +3,7 @@ var assert = require("assert"),
 	when = require("../promise").when,
 	whenPromise = require("../promise").whenPromise,
 	defer = require("../promise").defer,
-	asPromise = require("../promise").asPromise
+	Promise = require("../promise"),
 	Step = require("../step").Step;
 
 exports.testSpeedPlainValue = function(){
@@ -113,24 +113,25 @@ exports.testStep = function(){
 };
 
 exports.testAsValue = function (){
-	var deferred = asPromise("supercala");
+	var deferred = Promise.as("supercala");
 	deferred.then(function (res) {
 		assert.ok(res == "supercala");
 	}, function () {
 		throw new Error("Unexpected error");
 	});
-}
+};
 
 exports.testAsPromise = function (){
 	var temp = defer();
 	temp.resolve("supercala");
-	var deferred = asPromise(temp);
+	var deferred = Promise.as(temp);
+	assert.ok(temp === deferred);
 	deferred.then(function (res) {
 		assert.ok(res == "supercala");
 	}, function () {
 		throw new Error("Unexpected error");
 	});
-}
+};
 
 if (require.main === module)
     require("patr/runner").run(exports);


### PR DESCRIPTION
It's sometimes useful to ensure that an arbitrary value is always returned as a promise. This functionality is included in WinJS, and would be great to have in promised-io. See MSDN docs here: http://msdn.microsoft.com/en-us/library/windows/apps/br211664.aspx
