### PR TITLE
Report fs.close errors

### DIFF
--- a/fs.js
+++ b/fs.js
@@ -49,8 +49,13 @@ function File(fd){
 						return;
 					}
 					if (bytesRead === 0){
-						fs.close(fd);
-						deferred.resolve();
+						fs.close(fd, function (err) {
+							if(err){
+								deferred.reject(err);
+								return;
+							}
+							deferred.resolve();
+						});
 					}
 					else {
 						var result;


### PR DESCRIPTION
This makes sure errors are properly reported in case they occur. Otherwise it would be silent. The current behavior is long deprecated and will throw from Node.js 10.x on. See https://github.com/nodejs/node/pull/18668. 