### PR TITLE
Fix `promised-io/fs` failing to load

### DIFF
--- a/fs.js
+++ b/fs.js
@@ -20,7 +20,7 @@ var fs = require("fs"),
 
 // convert all the non-sync functions that have a sync counterpart
 for (var i in fs) {
-	if ((i + 'Sync') in fs) {
+	if (typeof fs[i + "Sync"] === "function") {
 		// async
 		exports[i] = convertNodeAsyncFunction(fs[i], i === "readFile");
 	}


### PR DESCRIPTION
When `require`-ing `promised-io/fs`, this error is being thrown:

```
TypeError: Cannot read property 'length' of undefined
   at exports.convertNodeAsyncFunction (C:\some-module\node_modules\promised-io\promise.js:687:28)
   at Object.<anonymous> (C:\some-module\node_modules\promised-io\fs.js:26:16)
   at Module._compile (internal/modules/cjs/loader.js:702:30)
```

This started in Node 10.5.0 because the `fs` module started exporting values that are not functions.

This PR fixes the problem by ensuring that the value is a function before trying to promisify it.