### PR TITLE
Check for presence of method in 'fs' module

### DIFF
--- a/fs.js
+++ b/fs.js
@@ -22,7 +22,9 @@ var fs = require("fs"),
 for (var i in fs) {
 	if ((i + 'Sync') in fs) {
 		// async
-		exports[i] = convertNodeAsyncFunction(fs[i], i === "readFile");
+		if (fs[i]) {
+			exports[i] = convertNodeAsyncFunction(fs[i], i === "readFile");
+		}
 	}
 	else{
 		// sync, or something that we can't auto-convert


### PR DESCRIPTION
At some point in the Node.js v10.x release cycle the behavior of conditionally available properties changed. `fs.lchmod` is only available on macOS, so in Node.js v10.0.0 not running in macOS the expression `'lchmod' in fs` evaluates to `false`. However, by Node.js v10.20.1 (I'm not sure exactly which release changed the behavior, I only tested v10.0.0 and v10.20.1) `'lchmod' in fs` evaluates to `true` although `fs.lchmod` is `undefined`. This change adds a guard check for `fs[i]` to prevent calling `convertNodeAsyncFunction` with `undefined`.

Fixes #62